### PR TITLE
Update path-util to 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
   "require": {
     "symfony/yaml": "2.*",
     "symfony/console": "2.*",
-    "webmozart/path-util": "~1.1"
+    "webmozart/path-util": "^2.3"
   },
   "type": "cli",
   "license": "GPLv2+",


### PR DESCRIPTION
This upgrade is necessary for using the latest drush version along with this project.

