### PR TITLE
Update symfony/yaml dependency version to 3.*

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
   "name": "derhasi/symlinker",
   "description": "A PHP library and CLI tool to create symlinks",
   "require": {
-    "symfony/yaml": "2.* || ~3.2.0",
+    "symfony/yaml": "2.* || 3.*",
     "symfony/console": "2.* || 3.*",
     "webmozart/path-util": "2.*"
   },


### PR DESCRIPTION
Currently the required version for `symfony/yaml` is `~3.2.0`. Unfortunately this does not allow to use this package with Drupal 8.5.0, which requires `~3.4.5`.

So here is a pull request to bump this version to `3.*` to have it compatible with Drupal <=8.5.0.

*NOTE:* This PR is also necessary for the corresponding update of [derhasi/boxfile](https://github.com/derhasi/boxfile) - see: https://github.com/derhasi/boxfile/pull/5